### PR TITLE
Fix topbar menu click behavior on smaller screens

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,6 +30,7 @@ module.exports = /** @param eleventyConfig {UserConfig} */ function (eleventyCon
   // be sure to add the directory to .eleventyignore
   eleventyConfig.addPassthroughCopy("img");
   eleventyConfig.addPassthroughCopy("fnt");
+  eleventyConfig.addPassthroughCopy("js");
   eleventyConfig.addPassthroughCopy(".htaccess");
   eleventyConfig.addPassthroughCopy("robots.txt");
   eleventyConfig.addPassthroughCopy("asdoc");

--- a/_includes/basic.html
+++ b/_includes/basic.html
@@ -42,6 +42,7 @@ limitations under the License.
     </div>
   </div>
   {% include "footer.html" %}
+  <script src="/js/topbar.js"></script>
 </body>
 
 </html>

--- a/_includes/blog-post.html
+++ b/_includes/blog-post.html
@@ -44,6 +44,7 @@ limitations under the License.
     </div>
   </div>
   {% include "footer.html" %}
+  <script src="/js/topbar.js"></script>
 </body>
 
 </html>

--- a/_includes/marketing.html
+++ b/_includes/marketing.html
@@ -40,6 +40,7 @@ limitations under the License.
     {{ content }}
   </div>
   {% include "footer.html" %}
+  <script src="/js/topbar.js"></script>
 </body>
 
 </html>

--- a/_includes/sass/royale-theme-topbar.sass
+++ b/_includes/sass/royale-theme-topbar.sass
@@ -127,11 +127,20 @@
   .topMenu > li > a:hover
     background-color: #e7e7e7
 
-  .topbar-right:hover .topMenu
-    display: flex
-    z-index: 1000
 
 @media (max-width: 599px)
   .topbar-left
     div
       width: 140px
+
+@media screen and (max-width: 840px)
+  .topMenu
+    display: none
+    flex-direction: column
+    position: absolute
+    right: 10px
+    top: 70px
+    z-index: 1000
+
+  .topMenu.is-open
+    display: flex

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -1,0 +1,20 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const btn = document.querySelector(".topMenu-dropbtn");
+  const menu = document.querySelector(".topMenu");
+
+  if (!btn || !menu) return;
+
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    menu.classList.toggle("is-open");
+  });
+
+  menu.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+
+  document.addEventListener("click", () => {
+    menu.classList.remove("is-open");
+  });
+});


### PR DESCRIPTION
## Problem

- The top bar menu used hover-based interactions to display navigation links.
- Hover behaviour is unreliable on touch devices and caused to open the features page unintentionally.

## What Changed

- Replaced hover-based menu behaviour with a click-based toggle for mobile devices.

## Screenshots

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/c556eab2-668d-4b2f-b44a-9bc441572a3b" controls width="300"></video> | <video src="https://github.com/user-attachments/assets/64a48f0d-8c9a-499f-bb69-8ba24cfead53" controls width="300"></video> |





